### PR TITLE
Pass TS_NODE_FILES=true to ts-node in integration tests.

### DIFF
--- a/src/__tests__/integration/main.spec.ts
+++ b/src/__tests__/integration/main.spec.ts
@@ -5,7 +5,9 @@ const bin = resolve(__dirname, './bin.js');
 
 describe('my-command', () => {
   it('should display the help contents', async () => {
-    const { stdout } = await execa(bin, ['--help']);
+    const { stdout } = await execa(bin, ['--help'], {
+      env: { TS_NODE_FILES: 'true' },
+    });
 
     expect(stdout).toContain('Usage: my-command [options]');
   });


### PR DESCRIPTION
This is needed to make sure that integration tests can pick up custom type declaration files which are sometimes needed for thirdparty JS modules.

### Description of change
Set TS_NODE_FILES=true env var when running integration tests via `execa`.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
